### PR TITLE
Remove custom image for CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,6 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: StandaloneWindows64
-          customImage: 'unityci/editor:ubuntu-2022.3.10f1-webgl-2'
 
       # - name: Move to one layer folder
       #   run: |


### PR DESCRIPTION
I needed this for a previous build in the project I copied the CI from as we were using a recently released version of Unity that wasn't in the game-ci repo yet. The up to date Unity builder is probably in the repo now, and the image is for WebGL only (game-ci/unity-builder selects images based on your build target)