### PR TITLE
Add initial pass at codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/ @fuseinabowl


### PR DESCRIPTION
Codeowners is described here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners This is supposed to automatically detect attacks as part of another otherwise good commit. Even if other contributors are added to the repo, I don't want them to be able to accidentally approve changes that let CI changes in. Unchecked attacks could use up all my compute minutes or steal github secrets.